### PR TITLE
Update Maven POM to create JAR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language:  java
 
+cache:
+  directories:
+  - "$HOME/.m2"
+
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,28 @@ jobs:
       jdk: openjdk8
 
     - jdk: openjdk11
+
+    - stage: deploy
+      if: tag IS present
+      jdk: openjdk11
+      install: skip
+      script: skip
+      if: tag IS present
+      before_deploy:
+        - mvn clean
+        - sed -i "s|<version>0.0.1-SNAPSHOT</version>|<version>${TRAVIS_TAG}</version>|" pom.xml
+        - sed -i "s|<version>0.0.1-SNAPSHOT</version>|<version>${TRAVIS_TAG}</version>|" hapl-obs/pom.xml
+        - sed -i "s|<version>0.0.1-SNAPSHOT</version>|<version>${TRAVIS_TAG}</version>|" hapl-obs-tools/pom.xml
+        - mvn package -Dmaven.test.skip=true
+
+      deploy:
+        provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        skip_cleanup: true
+        file_glob: true
+        file:
+          - "hapl-obs/target/*.jar"
+          - "hapl-obs-tools/target/hapl-obs-tools*"
+        on:
+          tags: true
+          all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,9 @@ cache:
   directories:
   - "$HOME/.m2"
 
-jdk:
-  - openjdk8
+jobs:
+  include:
+    - stage: test
+      jdk: openjdk8
+
+    - jdk: openjdk11


### PR DESCRIPTION
This pull request updates the Maven POM to support creating a single .jar file with all of the haplObserve code, plus all of the dependencies.  That jar can be given to other people, so they can run the code without needing the source code (or a Maven installation).